### PR TITLE
Implement WorldGuard region search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,13 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.13.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
             <version>7.0.2</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.themoep</groupId>
     <artifactId>entitydetection</artifactId>
-    <version>1.1.3</version>
+    <version>1.2.0</version>
     <description>Bukkit plugin to find groups of mobs, animals or other (tile) entities.</description>
     <name>EntityDetection</name>
 
@@ -22,6 +22,10 @@
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>enginehub-repo</id>
+            <url>https://maven.enginehub.org/repo/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -29,6 +33,11 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.13.2-R0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-bukkit</artifactId>
+            <version>7.0.2</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/de/themoep/entitydetection/EntityDetection.java
+++ b/src/main/java/de/themoep/entitydetection/EntityDetection.java
@@ -141,7 +141,7 @@ public class EntityDetection extends JavaPlugin {
                                     )
                             )
                             .event(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/detect tp " + (line + 1)))
-                            .append(entry.getChunk() + " ")
+                            .append(entry.getLocation() + " ")
                             .color(net.md_5.bungee.api.ChatColor.YELLOW)
                             .append(entry.getSize() + " ")
                             .color(net.md_5.bungee.api.ChatColor.RED);
@@ -175,7 +175,7 @@ public class EntityDetection extends JavaPlugin {
                 for(int line = start; line < start + 10 && line < chunkEntries.size(); line++) {
                     SearchResultEntry<?> chunkEntry = chunkEntries.get(line);
 
-                    String lineText = ChatColor.WHITE + " " + (line + 1) + ": " + ChatColor.YELLOW + chunkEntry.getChunk() + " " + ChatColor.RED + chunkEntry.getSize() + " ";
+                    String lineText = ChatColor.WHITE + " " + (line + 1) + ": " + ChatColor.YELLOW + chunkEntry.getLocation() + " " + ChatColor.RED + chunkEntry.getSize() + " ";
 
                     int entitiesListed = 0;
                     for(Entry<String, Integer> entityEntry : chunkEntry.getEntryCount()) {

--- a/src/main/java/de/themoep/entitydetection/EntityDetection.java
+++ b/src/main/java/de/themoep/entitydetection/EntityDetection.java
@@ -16,7 +16,6 @@ import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -49,9 +48,9 @@ public class EntityDetection extends JavaPlugin {
 
     private EntitySearch currentSearch;
 
-    private Map<SearchType, SearchResult> results = new HashMap<SearchType, SearchResult>();
-    private Map<String, SearchResult> customResults = new HashMap<String, SearchResult>();
-    private Map<String, SearchResult> lastResultViewed = new HashMap<String, SearchResult>();
+    private Map<SearchType, SearchResult<?>> results = new HashMap<>();
+    private Map<String, SearchResult<?>> customResults = new HashMap<>();
+    private Map<String, SearchResult<?>> lastResultViewed = new HashMap<>();
 
     private boolean serverIsSpigot = true;
 
@@ -84,7 +83,7 @@ public class EntityDetection extends JavaPlugin {
         return true;
     }
 
-    public void addResult(SearchResult result) {
+    public void addResult(SearchResult<?> result) {
         if(result.getType() == SearchType.CUSTOM && result.getSearched().size() == 1) {
             Set<String> searchedEntities = result.getSearched();
             customResults.put(searchedEntities.toArray(new String[searchedEntities.size()])[0], result);
@@ -97,12 +96,12 @@ public class EntityDetection extends JavaPlugin {
         return currentSearch;
     }
 
-    public void send(CommandSender sender, SearchResult result) {
+    public void send(CommandSender sender, SearchResult<?> result) {
         send(sender, result, 0);
     }
 
 
-    public void send(CommandSender sender, SearchResult result, int page) {
+    public void send(CommandSender sender, SearchResult<?> result, int page) {
         lastResultViewed.put(sender.getName(), result);
 
         String dateStr = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(result.getEndTime()));
@@ -124,10 +123,10 @@ public class EntityDetection extends JavaPlugin {
                     .append("from " + dateStr + ":")
                     .color(net.md_5.bungee.api.ChatColor.WHITE);
 
-            List<SearchResultEntry> results = result.getSortedEntries();
+            List<? extends SearchResultEntry<?>> results = result.getSortedEntries();
             if(results.size() > 0) {
                 for(int line = start; line < start + 10 && line < results.size(); line++) {
-                    SearchResultEntry entry = results.get(line);
+                    SearchResultEntry<?> entry = results.get(line);
 
                     builder.append("\n")
                             .retain(ComponentBuilder.FormatRetention.NONE)
@@ -171,10 +170,10 @@ public class EntityDetection extends JavaPlugin {
             List<String> msg = new ArrayList<String>();
             msg.add(ChatColor.GREEN + Utils.enumToHumanName(result.getType()) + " search " + ChatColor.WHITE + "from " + dateStr + ":");
 
-            List<SearchResultEntry> chunkEntries = result.getSortedEntries();
+            List<? extends SearchResultEntry<?>> chunkEntries = result.getSortedEntries();
             if(chunkEntries.size() > 0) {
                 for(int line = start; line < start + 10 && line < chunkEntries.size(); line++) {
-                    SearchResultEntry chunkEntry = chunkEntries.get(line);
+                    SearchResultEntry<?> chunkEntry = chunkEntries.get(line);
 
                     String lineText = ChatColor.WHITE + " " + (line + 1) + ": " + ChatColor.YELLOW + chunkEntry.getChunk() + " " + ChatColor.RED + chunkEntry.getSize() + " ";
 
@@ -195,15 +194,15 @@ public class EntityDetection extends JavaPlugin {
         }
     }
 
-    public SearchResult getResult(CommandSender sender) {
+    public SearchResult<?> getResult(CommandSender sender) {
         return lastResultViewed.get(sender.getName());
     }
 
-    public SearchResult getResult(String type) {
+    public SearchResult<?> getResult(String type) {
         return customResults.get(type);
     }
 
-    public SearchResult getResult(SearchType type) {
+    public SearchResult<?> getResult(SearchType type) {
         return results.get(type);
     }
 }

--- a/src/main/java/de/themoep/entitydetection/commands/ListSubCommand.java
+++ b/src/main/java/de/themoep/entitydetection/commands/ListSubCommand.java
@@ -39,7 +39,7 @@ public class ListSubCommand extends SubCommand {
 
     @Override
     public boolean execute(CommandSender sender, String[] args) {
-        SearchResult result = getPlugin().getResult(sender);
+        SearchResult<?> result = getPlugin().getResult(sender);
         int page = 1;
         String lastName = sender.getName();
         if(args.length > 0) {

--- a/src/main/java/de/themoep/entitydetection/commands/SearchSubCommand.java
+++ b/src/main/java/de/themoep/entitydetection/commands/SearchSubCommand.java
@@ -3,10 +3,12 @@ package de.themoep.entitydetection.commands;
 import de.themoep.entitydetection.EntityDetection;
 import de.themoep.entitydetection.searcher.EntitySearch;
 import de.themoep.entitydetection.searcher.SearchType;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.EntityType;
+import org.bukkit.plugin.Plugin;
 
 /**
  * Copyright 2016 Max Lee (https://github.com/Phoenix616/)
@@ -36,6 +38,17 @@ public class SearchSubCommand extends SubCommand {
         EntitySearch search = new EntitySearch(getPlugin(), sender);
         if(args.length > 0) {
             for(String arg : args) {
+                if ("--regions".equalsIgnoreCase(arg)) {
+                    Plugin plugin = Bukkit.getPluginManager().getPlugin("WorldGuard");
+                    if (plugin != null && plugin.isEnabled() && plugin.getDescription().getVersion().startsWith("7"))
+                        search.setWorldGuardRegion(true);
+                    else {
+                        sender.sendMessage(ChatColor.RED + "Unable to start WorldGuard search. WorldGuard not enabled or outdated!");
+                        return true;
+                    }
+                    if (args.length == 1) search.setType(SearchType.MONSTER);
+                    continue;
+                }
                 if (arg.endsWith("s")) {
                     arg = arg.substring(0, arg.length() - 1);
                 }

--- a/src/main/java/de/themoep/entitydetection/commands/TpSubCommand.java
+++ b/src/main/java/de/themoep/entitydetection/commands/TpSubCommand.java
@@ -46,7 +46,10 @@ public class TpSubCommand extends SubCommand {
         if(args.length == 0) {
             return false;
         }
-        SearchResult<?> lastResult = getPlugin().getResult(sender);
+        return teleport((Player)sender, args[0], getPlugin().getResult(sender));
+    }
+
+    private <T> boolean teleport(Player sender, String page, SearchResult<T> lastResult) {
         if(lastResult == null) {
             sender.sendMessage(ChatColor.RED + "You have to view a search result before teleporting to an entry! Use /detect search or /detect list [<type>]");
             return true;
@@ -54,19 +57,19 @@ public class TpSubCommand extends SubCommand {
 
         int i;
         try {
-            i = Integer.parseInt(args[0]);
+            i = Integer.parseInt(page);
         } catch(NumberFormatException e) {
-            sender.sendMessage(ChatColor.YELLOW + args[0] + ChatColor.RED + " is not a proper number input!");
+            sender.sendMessage(ChatColor.YELLOW + page + ChatColor.RED + " is not a proper number input!");
             return false;
         }
 
         if(i == 0 || lastResult.getSortedEntries().size() < i) {
-            sender.sendMessage(ChatColor.RED + "Result " + ChatColor.YELLOW + args[0] + ChatColor.RED + " is not in the list!");
+            sender.sendMessage(ChatColor.RED + "Result " + ChatColor.YELLOW + page + ChatColor.RED + " is not in the list!");
             return true;
         }
 
-        SearchResultEntry<?> entry = lastResult.getSortedEntries().get(i - 1);
-        lastResult.teleport((Player)sender, entry, i);
+        SearchResultEntry<T> entry = lastResult.getSortedEntries().get(i - 1);
+        lastResult.teleport(sender, entry, i);
         return true;
     }
 }

--- a/src/main/java/de/themoep/entitydetection/commands/TpSubCommand.java
+++ b/src/main/java/de/themoep/entitydetection/commands/TpSubCommand.java
@@ -46,7 +46,7 @@ public class TpSubCommand extends SubCommand {
         if(args.length == 0) {
             return false;
         }
-        SearchResult lastResult = getPlugin().getResult(sender);
+        SearchResult<?> lastResult = getPlugin().getResult(sender);
         if(lastResult == null) {
             sender.sendMessage(ChatColor.RED + "You have to view a search result before teleporting to an entry! Use /detect search or /detect list [<type>]");
             return true;
@@ -65,42 +65,8 @@ public class TpSubCommand extends SubCommand {
             return true;
         }
 
-        SearchResultEntry entry = lastResult.getSortedEntries().get(i - 1);
-
-        try {
-            Chunk chunk = entry.getChunk().toBukkit(getPlugin().getServer());
-
-            Location loc = null;
-
-            for(Entity e : chunk.getEntities()) {
-                if(e.getType().toString().equals(entry.getEntryCount().get(0).getKey())) {
-                    loc = e.getLocation();
-                    break;
-                }
-            }
-
-            for (BlockState b : chunk.getTileEntities()) {
-                if(b.getType().toString().equals(entry.getEntryCount().get(0).getKey())) {
-                    loc = b.getLocation().add(0, 1, 0);
-                    break;
-                }
-            }
-
-            if (loc == null) {
-                loc = chunk.getWorld().getHighestBlockAt(chunk.getX() * 16 + 8, chunk.getZ() * 16 + 8).getLocation().add(0, 2, 0);
-            }
-
-            ((Player) sender).teleport(loc, PlayerTeleportEvent.TeleportCause.PLUGIN);
-            sender.sendMessage(
-                    ChatColor.GREEN + "Teleported to entry " + ChatColor.WHITE + i + ": " +
-                            ChatColor.YELLOW + entry.getChunk() + " " + ChatColor.RED + entry.getSize() + " " +
-                            ChatColor.GREEN + Utils.enumToHumanName(entry.getEntryCount().get(0).getKey()) + "[" +
-                            ChatColor.WHITE + entry.getEntryCount().get(0).getValue() + ChatColor.GREEN + "]"
-            );
-
-        } catch(IllegalArgumentException e) {
-            sender.sendMessage(ChatColor.RED + e.getMessage());
-        }
+        SearchResultEntry<?> entry = lastResult.getSortedEntries().get(i - 1);
+        lastResult.teleport((Player)sender, entry, i);
         return true;
     }
 }

--- a/src/main/java/de/themoep/entitydetection/searcher/ChunkSearchResult.java
+++ b/src/main/java/de/themoep/entitydetection/searcher/ChunkSearchResult.java
@@ -39,7 +39,7 @@ public class ChunkSearchResult extends SearchResult<ChunkLocation> {
     @Override
     public void teleport(Player sender, SearchResultEntry<ChunkLocation> entry, int i) {
         try {
-            Chunk chunk = entry.getChunk().toBukkit(Bukkit.getServer());
+            Chunk chunk = entry.getLocation().toBukkit(Bukkit.getServer());
 
             Location loc = null;
 
@@ -64,7 +64,7 @@ public class ChunkSearchResult extends SearchResult<ChunkLocation> {
             sender.teleport(loc, PlayerTeleportEvent.TeleportCause.PLUGIN);
             sender.sendMessage(
                     ChatColor.GREEN + "Teleported to entry " + ChatColor.WHITE + i + ": " +
-                            ChatColor.YELLOW + entry.getChunk() + " " + ChatColor.RED + entry.getSize() + " " +
+                            ChatColor.YELLOW + entry.getLocation() + " " + ChatColor.RED + entry.getSize() + " " +
                             ChatColor.GREEN + Utils.enumToHumanName(entry.getEntryCount().get(0).getKey()) + "[" +
                             ChatColor.WHITE + entry.getEntryCount().get(0).getValue() + ChatColor.GREEN + "]"
             );

--- a/src/main/java/de/themoep/entitydetection/searcher/ChunkSearchResult.java
+++ b/src/main/java/de/themoep/entitydetection/searcher/ChunkSearchResult.java
@@ -37,8 +37,7 @@ public class ChunkSearchResult extends SearchResult<ChunkLocation> {
     }
 
     @Override
-    public void teleport(Player sender, SearchResultEntry<?> oldEntry, int i) {
-        SearchResultEntry<ChunkLocation> entry = (SearchResultEntry<ChunkLocation>)oldEntry;
+    public void teleport(Player sender, SearchResultEntry<ChunkLocation> entry, int i) {
         try {
             Chunk chunk = entry.getChunk().toBukkit(Bukkit.getServer());
 

--- a/src/main/java/de/themoep/entitydetection/searcher/ChunkSearchResult.java
+++ b/src/main/java/de/themoep/entitydetection/searcher/ChunkSearchResult.java
@@ -1,0 +1,77 @@
+package de.themoep.entitydetection.searcher;
+
+import de.themoep.entitydetection.ChunkLocation;
+import de.themoep.entitydetection.Utils;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.block.BlockState;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+public class ChunkSearchResult extends SearchResult<ChunkLocation> {
+    public ChunkSearchResult(EntitySearch search) {
+        super(search);
+    }
+
+    @Override
+    public void addEntity(Entity entity) {
+        add(entity.getLocation(), entity.getType().toString());
+    }
+
+    @Override
+    public void addBlockState(BlockState blockState) {
+        add(blockState.getLocation(), blockState.getType().toString());
+    }
+
+    @Override
+    public void add(Location location, String type) {
+        ChunkLocation chunkLocation = new ChunkLocation(location);
+
+        if(!resultEntryMap.containsKey(chunkLocation)) {
+            resultEntryMap.put(chunkLocation, new SearchResultEntry<>(chunkLocation));
+        }
+        resultEntryMap.get(chunkLocation).increment(type);
+    }
+
+    @Override
+    public void teleport(Player sender, SearchResultEntry<?> oldEntry, int i) {
+        SearchResultEntry<ChunkLocation> entry = (SearchResultEntry<ChunkLocation>)oldEntry;
+        try {
+            Chunk chunk = entry.getChunk().toBukkit(Bukkit.getServer());
+
+            Location loc = null;
+
+            for(Entity e : chunk.getEntities()) {
+                if(e.getType().toString().equals(entry.getEntryCount().get(0).getKey())) {
+                    loc = e.getLocation();
+                    break;
+                }
+            }
+
+            for (BlockState b : chunk.getTileEntities()) {
+                if(b.getType().toString().equals(entry.getEntryCount().get(0).getKey())) {
+                    loc = b.getLocation().add(0, 1, 0);
+                    break;
+                }
+            }
+
+            if (loc == null) {
+                loc = chunk.getWorld().getHighestBlockAt(chunk.getX() * 16 + 8, chunk.getZ() * 16 + 8).getLocation().add(0, 2, 0);
+            }
+
+            sender.teleport(loc, PlayerTeleportEvent.TeleportCause.PLUGIN);
+            sender.sendMessage(
+                    ChatColor.GREEN + "Teleported to entry " + ChatColor.WHITE + i + ": " +
+                            ChatColor.YELLOW + entry.getChunk() + " " + ChatColor.RED + entry.getSize() + " " +
+                            ChatColor.GREEN + Utils.enumToHumanName(entry.getEntryCount().get(0).getKey()) + "[" +
+                            ChatColor.WHITE + entry.getEntryCount().get(0).getValue() + ChatColor.GREEN + "]"
+            );
+
+        } catch(IllegalArgumentException e) {
+            sender.sendMessage(ChatColor.RED + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/de/themoep/entitydetection/searcher/EntitySearch.java
+++ b/src/main/java/de/themoep/entitydetection/searcher/EntitySearch.java
@@ -46,6 +46,8 @@ public class EntitySearch extends BukkitRunnable {
     private List<Entity> entities = new ArrayList<Entity>();
     private List<BlockState> blockStates = new ArrayList<BlockState>();
 
+    private boolean isWorldGuardRegion = false;
+
     public EntitySearch(EntityDetection plugin, CommandSender sender) {
         this.plugin = plugin;
         owner = sender;
@@ -100,6 +102,13 @@ public class EntitySearch extends BukkitRunnable {
         return startTime;
     }
 
+    public boolean isWorldGuardRegion() {
+        return this.isWorldGuardRegion;
+    }
+
+    public void setWorldGuardRegion(boolean value) {
+        this.isWorldGuardRegion = value;
+    }
     /**
      * Get the duration since this search started
      * @return The duration in seconds
@@ -138,7 +147,9 @@ public class EntitySearch extends BukkitRunnable {
 
     public void run() {
         startTime = System.currentTimeMillis();
-        SearchResult result = new SearchResult(this);
+        SearchResult<?> result;
+        if(isWorldGuardRegion) result = new WGSearchResult(this);
+        else result = new ChunkSearchResult(this);
 
         for(Entity e : entities) {
             if(!running) {
@@ -159,7 +170,7 @@ public class EntitySearch extends BukkitRunnable {
         }
 
         result.sort();
-        plugin.addResult(result);;
+        plugin.addResult(result);
         plugin.send(owner, result);
         running = false;
     }

--- a/src/main/java/de/themoep/entitydetection/searcher/SearchResult.java
+++ b/src/main/java/de/themoep/entitydetection/searcher/SearchResult.java
@@ -116,5 +116,5 @@ public abstract class SearchResult<T> {
         endTime = System.currentTimeMillis();
     }
 
-    public abstract void teleport(Player sender, SearchResultEntry<?> entry, int i);
+    public abstract void teleport(Player sender, SearchResultEntry<T> entry, int i);
 }

--- a/src/main/java/de/themoep/entitydetection/searcher/SearchResultEntry.java
+++ b/src/main/java/de/themoep/entitydetection/searcher/SearchResultEntry.java
@@ -1,7 +1,5 @@
 package de.themoep.entitydetection.searcher;
 
-import de.themoep.entitydetection.ChunkLocation;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -24,14 +22,14 @@ import java.util.Map;
  * You should have received a copy of the Mozilla Public License v2.0
  * along with this program. If not, see <http://mozilla.org/MPL/2.0/>.
  */
-public class SearchResultEntry implements Comparable<SearchResultEntry> {
-    private ChunkLocation chunk;
+public class SearchResultEntry<T> implements Comparable<SearchResultEntry<T>> {
+    private T location;
     private Map<String, Integer> entryCount = new HashMap<String, Integer>();
     private List<Map.Entry<String, Integer>> finalList = new ArrayList<Map.Entry<String, Integer>>();
     private int size = 0;
 
-    SearchResultEntry(ChunkLocation chunk) {
-        this.chunk = chunk;
+    SearchResultEntry(T location) {
+        this.location = location;
     }
 
     public void increment(String type) {
@@ -47,8 +45,8 @@ public class SearchResultEntry implements Comparable<SearchResultEntry> {
         return size;
     }
 
-    public ChunkLocation getChunk() {
-        return chunk;
+    public T getChunk() {
+        return location;
     }
 
     public List<Map.Entry<String, Integer>> getEntryCount() {
@@ -56,12 +54,8 @@ public class SearchResultEntry implements Comparable<SearchResultEntry> {
     }
 
     public void sort() {
-        finalList = new ArrayList<Map.Entry<String, Integer>>(entryCount.entrySet());
-        Collections.sort(finalList, Collections.reverseOrder(new Comparator<Map.Entry<String, Integer>>() {
-            public int compare(Map.Entry<String, Integer> o1, Map.Entry<String, Integer> o2) {
-                return Integer.compare(o1.getValue(), o2.getValue());
-            }
-        }));
+        finalList = new ArrayList<>(entryCount.entrySet());
+        finalList.sort(Collections.reverseOrder(Comparator.comparingInt(Map.Entry::getValue)));
     }
 
     public int compareTo(SearchResultEntry o) {

--- a/src/main/java/de/themoep/entitydetection/searcher/SearchResultEntry.java
+++ b/src/main/java/de/themoep/entitydetection/searcher/SearchResultEntry.java
@@ -45,7 +45,7 @@ public class SearchResultEntry<T> implements Comparable<SearchResultEntry<T>> {
         return size;
     }
 
-    public T getChunk() {
+    public T getLocation() {
         return location;
     }
 

--- a/src/main/java/de/themoep/entitydetection/searcher/WGSearchResult.java
+++ b/src/main/java/de/themoep/entitydetection/searcher/WGSearchResult.java
@@ -47,8 +47,7 @@ public class WGSearchResult extends SearchResult<WGSearchResult.ProtectedRegionE
     }
 
     @Override
-    public void teleport(Player sender, SearchResultEntry<?> oldEntry, int i) {
-        SearchResultEntry<WGSearchResult.ProtectedRegionEntry> entry = (SearchResultEntry<WGSearchResult.ProtectedRegionEntry>) oldEntry;
+    public void teleport(Player sender, SearchResultEntry<WGSearchResult.ProtectedRegionEntry> entry, int i) {
         com.sk89q.worldedit.util.Location wgLocation = entry.getChunk().region.getFlag(Flags.TELE_LOC);
         try {
             Location loc = wgLocation != null ? BukkitAdapter.adapt(wgLocation) : null;

--- a/src/main/java/de/themoep/entitydetection/searcher/WGSearchResult.java
+++ b/src/main/java/de/themoep/entitydetection/searcher/WGSearchResult.java
@@ -1,0 +1,100 @@
+package de.themoep.entitydetection.searcher;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import com.sk89q.worldguard.protection.regions.RegionQuery;
+import de.themoep.entitydetection.Utils;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.BlockState;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+import java.util.Objects;
+
+public class WGSearchResult extends SearchResult<WGSearchResult.ProtectedRegionEntry> {
+    public WGSearchResult(EntitySearch search) {
+        super(search);
+    }
+
+    @Override
+    public void addEntity(Entity entity) {
+        add(entity.getLocation(), entity.getType().toString());
+    }
+
+    @Override
+    public void addBlockState(BlockState blockState) {
+        add(blockState.getLocation(), blockState.getType().toString());
+    }
+
+    @Override
+    public void add(Location location, String type) {
+        RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
+        ApplicableRegionSet applicableRegions = query.getApplicableRegions(BukkitAdapter.adapt(location));
+
+        applicableRegions.forEach(region -> {
+            ProtectedRegionEntry protectedRegionEntry = new ProtectedRegionEntry(location.getWorld(), region);
+            if(!resultEntryMap.containsKey(protectedRegionEntry)) {
+                resultEntryMap.put(protectedRegionEntry, new SearchResultEntry<>(protectedRegionEntry));
+            }
+            resultEntryMap.get(protectedRegionEntry).increment(type);
+        });
+    }
+
+    @Override
+    public void teleport(Player sender, SearchResultEntry<?> oldEntry, int i) {
+        SearchResultEntry<WGSearchResult.ProtectedRegionEntry> entry = (SearchResultEntry<WGSearchResult.ProtectedRegionEntry>) oldEntry;
+        com.sk89q.worldedit.util.Location wgLocation = entry.getChunk().region.getFlag(Flags.TELE_LOC);
+        try {
+            Location loc = wgLocation != null ? BukkitAdapter.adapt(wgLocation) : null;
+            if(loc == null) {
+                loc = BukkitAdapter.adapt(entry.getChunk().world, entry.getChunk().region.getMinimumPoint().add(
+                        entry.getChunk().region.getMaximumPoint().subtract(entry.getChunk().region.getMinimumPoint()).divide(2)));
+            }
+
+            sender.teleport(loc, PlayerTeleportEvent.TeleportCause.PLUGIN);
+            sender.sendMessage(
+                    ChatColor.GREEN + "Teleported to entry " + ChatColor.WHITE + i + ": " +
+                            ChatColor.YELLOW + entry.getChunk().region.getId() + " " + ChatColor.RED + entry.getSize() + " " +
+                            ChatColor.GREEN + Utils.enumToHumanName(entry.getEntryCount().get(0).getKey()) + "[" +
+                            ChatColor.WHITE + entry.getEntryCount().get(0).getValue() + ChatColor.GREEN + "]"
+            );
+        } catch(IllegalArgumentException e) {
+            sender.sendMessage(ChatColor.RED + e.getMessage());
+        }
+    }
+
+    public static class ProtectedRegionEntry {
+        World world;
+        ProtectedRegion region;
+
+        public ProtectedRegionEntry(World world, ProtectedRegion region) {
+            this.world = world;
+            this.region = region;
+        }
+
+        @Override
+        public String toString() {
+            return "w: " + world.getName() + ", r: " + region.getId();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ProtectedRegionEntry that = (ProtectedRegionEntry) o;
+            return Objects.equals(world, that.world) &&
+                    Objects.equals(region, that.region);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(world, region);
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ main: de.themoep.entitydetection.EntityDetection
 version: '${minecraft.plugin.version}'
 api-version: 1.13
 description: '${project.description}'
+softdepend: ["WorldGuard"]
 authors: [Phoenix616]
 commands:
    entitydetection:


### PR DESCRIPTION
Adds a basic WorldGuard region search. Changed things:

- WorldGuard is now a softdepend
- Region search with /detect search --regions <filter>

I changed some internals to Generics, it should be easy to add more keys for search, not only ChunkLocation and World+ProtectedRegions.
Feel free to improve the display format for ProtectedRegions in the search field.