### PR TITLE
Optimize search command for tile entities on Paper servers

### DIFF
--- a/src/main/java/de/themoep/entitydetection/searcher/ChunkSearchResult.java
+++ b/src/main/java/de/themoep/entitydetection/searcher/ChunkSearchResult.java
@@ -62,7 +62,7 @@ public class ChunkSearchResult extends SearchResult<ChunkLocation> {
                     }
                 }
 
-                for (BlockState b : chunk.getTileEntities()) {
+                for (BlockState b : chunk.getTileEntities(false)) {
                     if (b.getType().toString().equals(entry.getEntryCount().get(0).getKey())) {
                         loc = b.getLocation().add(0, 1, 0);
                         break;

--- a/src/main/java/de/themoep/entitydetection/searcher/EntitySearch.java
+++ b/src/main/java/de/themoep/entitydetection/searcher/EntitySearch.java
@@ -155,7 +155,7 @@ public class EntitySearch implements Consumer<WrappedTask> {
                     scheduled++;
                     scheduler.runAtLocation(chunk.getBlock(0, 0, 0).getLocation(), task -> {
                         try {
-                            for (BlockState state : chunk.getTileEntities()) {
+                            for (BlockState state : chunk.getTileEntities(false)) {
                                 Multimap<Class, Location> multiMap = blockStates.get(state.getType());
                                 if (multiMap == null) {
                                     multiMap = MultimapBuilder.hashKeys().arrayListValues().build();


### PR DESCRIPTION
Avoid snapshots for Chunk#getTileEntities, small benchmarks here:
Before: https://spark.lucko.me/aR0fEPSZq0
<img width="534" height="255" alt="immagine" src="https://github.com/user-attachments/assets/e63b5ff5-6bc6-4e32-ba92-f11d6e78bdd9" />

After: https://spark.lucko.me/WFTL8lDgvZ
<img width="665" height="206" alt="immagine" src="https://github.com/user-attachments/assets/2e6ee0c2-aa0f-45f4-945d-37959773096b" />